### PR TITLE
change time

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,8 +15,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('installments:process')->everyTenMinutes();
-          $schedule->command('installments:process')->everyTwoMinutes();
+        $schedule->command('installments:process')->everyTenMinutes();
+        //   $schedule->command('installments:process')->everyTwoMinutes();
 
     }
 


### PR DESCRIPTION
This pull request updates the scheduling interval for the `installments:process` command in the application console kernel. The command is now set to run every ten minutes instead of every two minutes.

* Changed the scheduling of the `installments:process` command in `app/Console/Kernel.php` to run every ten minutes, reverting a previous change that set it to every two minutes.